### PR TITLE
Fix CSS handling flow 

### DIFF
--- a/MelteCompiler.js
+++ b/MelteCompiler.js
@@ -359,7 +359,7 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
             : { code: processedCode };
         },
         style: async ({ content, attributes }) => {
-          if (this.postcss && (!attributes.lang || attributes.lang === 'postcss')) {
+          if (this.postcss && attributes.lang === 'postcss') {
             const { css: code } = await this.postcss.process(content, { from: undefined });
 
             return {

--- a/MelteCompiler.js
+++ b/MelteCompiler.js
@@ -141,7 +141,7 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
   // The compile result returned from `compileOneFile` can be an array or an
   // object. If the processed HTML file is not a Svelte component, the result is
   // an array of HTML sections (head and/or body). Otherwise, it's an object
-  // with JavaScript from a compiled Svelte cmponent.
+  // with JavaScript from a compiled Svelte component.
   compileResultSize(result) {
     let size = 0;
 
@@ -149,7 +149,7 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
       result.forEach(section => size += section.data.length);
     } else {
       const { js, css } = result;
-      
+
       if (js && js.data) {
         size += js.data.length + js.sourceMap.toString().length;
       }
@@ -208,7 +208,7 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
         if (css) {
           file.addStylesheet(css);
         }
-        
+
         return js;
       });
     }
@@ -217,7 +217,7 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
   async compileOneFile(file) {
     // Search for head and body tags if lazy compilation isn't supported.
     // Otherwise, the file has already been parsed in `compileOneFileLater`.
-  
+
     if (!file.supportsLazyCompilation) {
       const sections = this.getHtmlSections(file);
 

--- a/MelteCompiler.js
+++ b/MelteCompiler.js
@@ -360,8 +360,10 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
         },
         style: async ({ content, attributes }) => {
           if (this.postcss && (!attributes.lang || attributes.lang === 'postcss')) {
+            const { css: code } = await this.postcss.process(content, { from: undefined });
+
             return {
-              code: await this.postcss.process(content, { from: undefined })
+              code
             };
           }
         }


### PR DESCRIPTION
Here is a somewhat working proof of concept as a result of me tinkering with the plugin (in case it might be useful).

`css: false` ➡️ All compiled Svelte components' CSS in merged into the stylesheets

`css: true` ➡️  CSS is included in the component code

Caching seems a bit broken, if I change from `css: false` to `css: true`, all styles are missing until a `meteor reset`.
