### PR TITLE
#3 Fix style preprocessing with Svelte versions 3.30.0 and beyond

### DIFF
--- a/MelteCompiler.js
+++ b/MelteCompiler.js
@@ -346,8 +346,10 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
         style: async ({ content, attributes }) => {
           if (this.postcss) {
             if (attributes.lang == 'postcss') {
+              const { css: code } = await this.postcss.process(content, { from: undefined });
+
               return {
-                code: await this.postcss.process(content, { from: undefined })
+                code
               };
             }
           }


### PR DESCRIPTION
Style preprocessor's return value's property `code` should hold just the CSS string, not the full result from PostCSS. This fixed implementation works with both 3.30.0+ and earlier versions of Svelte.

Things broke when Svelte hit `3.30.0` (https://github.com/sveltejs/svelte/pull/5584), changing style preprocessor flow by introducing sourcemap support.

Fixes #3 