### PR TITLE
Implement eager postcss preprocessing

### DIFF
--- a/MelteCompiler.js
+++ b/MelteCompiler.js
@@ -344,12 +344,10 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
             : { code: processedCode };
         },
         style: async ({ content, attributes }) => {
-          if (this.postcss) {
-            if (attributes.lang == 'postcss') {
-              return {
-                code: await this.postcss.process(content, { from: undefined })
-              };
-            }
+          if (this.postcss && (!attributes.lang || attributes.lang === 'postcss')) {
+            return {
+              code: await this.postcss.process(content, { from: undefined })
+            };
           }
         }
       })));


### PR DESCRIPTION
Uses PostCSS preprocessing, if `postcss` is configured & available and there is no conflicting `lang` attribute present in the `<style>` tag.

Fixes #5 