### PR TITLE
update recast & acorn versions

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -7,14 +7,14 @@
       "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ=="
     },
     "@types/estree": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
-      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg=="
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -22,9 +22,9 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="
     },
     "ast-types": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
-      "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.2.tgz",
+      "integrity": "sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -167,20 +167,15 @@
         }
       }
     },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
-    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA=="
     },
     "recast": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.19.0.tgz",
-      "integrity": "sha512-HymYANYaUFpKoAkOZ2od16SB7A/BwCZbvYIs9Rc8K+wNThQctiCJ0AjLkPbo9eWdy3w5Eemk6I4MeEYbH12PBg==",
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.20.5.tgz",
+      "integrity": "sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==",
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
@@ -213,6 +208,11 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.13.2.tgz",
       "integrity": "sha512-abXnVyhjxrTuKKuHVLsNk8bkbk3cmbkBzfVbVDI1PeBBB/PlfzRpYwTGHGznXNRvlDAHab9GxPpAGoUFJLXBVg=="
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.js
+++ b/package.js
@@ -12,9 +12,9 @@ Npm.depends({
   htmlparser2: '3.10.1',
   'postcss': '7.0.17',
   'source-map': '0.5.6',
-  'recast': '0.19.0',
+  'recast': '0.20.5',
   'periscopic': '2.0.2',
-  'acorn': '7.4.0',
+  'acorn': '8.6.0',
   '@babel/parser': '7.4.3'
 });
 


### PR DESCRIPTION
Optional chaining produce "ChainExpression" error:

Code example:

```js
$: {
    if ($companiesQuery.data?.Company_all) {
      // console.log($companiesQuery)
      let colsMax = $companiesQuery.data.Company_all.length / 2
      let col = []
      let _cols = []
      for (let row of $companiesQuery.data.Company_all) {
        col.push(row)
        if (col.length >= colsMax) {
          _cols.push(col)
          col = []
        }
      }
      if (col.length > 0) {
        _cols.push(col)
      }
      cols = _cols
    }
  }
```

Error output:

```bash
While building for web.browser:
imports/ui/pages/main/MainPage.svelte: did not recognize object of type "ChainExpression"
```

Update recast & acorn to latest versions.
