### PR TITLE
[NO_TICKET] [FIX] TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received null

### DIFF
--- a/MelteCompiler.js
+++ b/MelteCompiler.js
@@ -519,7 +519,7 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
       css = {
         path: file.getPathInPackage(),
         sourcePath: file.getPathInPackage(),
-        data: compiledResult.css.code,
+        data: compiledResult.css.code || '',
         sourceMap: compiledResult.css.map,
         lazy: false
       };


### PR DESCRIPTION
Hello, after the Meteor.js 3.0 update, when the css value from the svelte:complier properties is set to false, if there is no css in the svelte component, the value is sent as null. However, accepted values can be string, Buffer, TypedArray, or DataView. In this pr, if there is no value, an empty string is sent in a fixed way and the crash at the beginning of the application is solved.